### PR TITLE
Pollard finetune

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "bitcoincore-rpc",
+ "clap",
  "duckdb",
  "env_logger",
  "hex",
@@ -383,6 +384,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1051,6 +1102,52 @@ dependencies = [
  "num-traits",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comfy-table"
@@ -2046,6 +2143,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -3388,6 +3491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +3926,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utreexo"

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ cargo run --release
 
 Endpoints:
   - POST /build  `{ "parquet": "/path/to/utxo.parquet", "resume_from": null }`
-    → initializes and builds accumulator into `snapshot/`
+    → initializes and builds accumulator state, producing `mem_forest.bin` and `block_hashes.bin` in the working directory
   - POST /pause  → pause ongoing build
   - POST /resume → resume paused build
   - POST /stop   → stop processing
   - GET  /status → get current build status
-  - POST /update `{ "height": 680000 }` → apply a block update
+  - POST /update `{ "height": 680000 }` → apply a block update, updating `mem_forest.bin` and generating a fresh pruned `pollard.bin`
   - POST /dump   → write a pruned Pollard snapshot to `snapshot/`
   - POST /restore→ reload from last disk snapshot
 

--- a/accumulator-service/Cargo.toml
+++ b/accumulator-service/Cargo.toml
@@ -2,6 +2,10 @@
 name = "accumulator-service"
 version = "0.1.0"
 edition = "2021"
+[[bin]]
+name = "verify_update"
+path = "bin/verify_update.rs"
+edition = "2021"
 
 [[bin]]
 name = "server"
@@ -21,6 +25,7 @@ anyhow = "1.0"
 bitcoin = { version = "0.32", features = ["serde"] }
 rustreexo = { version = "0.4", features = ["with-serde"] }
 utreexo = { path = "../utreexo" }
+clap = { version = "4", features = ["derive"] }
 
 # on macOS, use the system (Homebrew) duckdb dylib
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/accumulator-service/bin/verify_update.rs
+++ b/accumulator-service/bin/verify_update.rs
@@ -1,0 +1,130 @@
+//! Standalone verifier: loads a pruned Pollard, fetches block H and H+1,
+//! and applies UTXO changes to advance the Pollard.
+use anyhow::{anyhow, Context, Result};
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use clap::Parser;
+use rustreexo::accumulator::node_hash::BitcoinNodeHash;
+use rustreexo::accumulator::pollard::{Pollard, PollardAddition};
+use rustreexo::accumulator::mem_forest::MemForest;
+use rustreexo::accumulator::proof::Proof;
+use std::fs::File;
+use std::io::{Cursor, Read};
+use std::path::PathBuf;
+use accumulator_service::script_utils::btc_rpc::{get_block_leaf_hashes, BitcoinRpc};
+use utreexo::LeafData;
+
+/// CLI arguments
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to the pruned Pollard file (pollard.bin)
+    #[arg(long)]
+    pollard: PathBuf,
+    /// Block height H to process updates for H and H+1
+    #[arg(long)]
+    height: u64,
+}
+
+fn main() -> Result<()> {
+    // Parse arguments
+    let args = Args::parse();
+
+    // (1) Load existing pruned Pollard
+    let mut pollard_bytes = Vec::new();
+    File::open(&args.pollard)
+        .with_context(|| format!("opening pollard file {:?}", args.pollard))?
+        .read_to_end(&mut pollard_bytes)?;
+    let mut rdr = Cursor::new(&pollard_bytes);
+    let mut pollard: Pollard<BitcoinNodeHash> =
+        Pollard::deserialize(&mut rdr).context("failed to deserialize pollard")?;
+    let prev_roots = pollard.roots().to_vec();
+    println!("Previous Utreexo roots: {:?}", prev_roots);
+
+    // (2) Connect to local Bitcoin Core RPC
+    let rpc_url = std::env::var("BITCOIN_CORE_RPC_URL").context("missing BITCOIN_CORE_RPC_URL")?;
+    let cookie = std::env::var("BITCOIN_CORE_COOKIE_FILE").context("missing BITCOIN_CORE_COOKIE_FILE")?;
+    let rpc_client = Client::new(&rpc_url, Auth::CookieFile(cookie.into()))
+        .context("failed to connect to Bitcoin RPC")?;
+    let rpc = RpcClient(rpc_client);
+
+    // (3) Fetch block H and H+1
+    let bh0 = rpc.get_block_hash(args.height)?;
+    let block0 = rpc.get_block(&bh0)?;
+    let h1 = args.height + 1;
+    let bh1 = rpc.get_block_hash(h1)?;
+    let block1 = rpc.get_block(&bh1)?;
+    println!("Block {} hash = {}", args.height, bh0);
+    println!("Block {} hash = {}", h1, bh1);
+
+    // (4) Verify difficulty target matches between blocks
+    if block0.header.bits != block1.header.bits {
+        eprintln!("Warning: bits mismatch: {:?} vs {:?}", block0.header.bits, block1.header.bits);
+    }
+
+    // (5) Compute deletes (spent UTXO leaves) for block H+1
+    let deletes = get_block_leaf_hashes(&rpc, h1)
+        .context("failed to fetch block leaf hashes")?;
+    println!("Deletes from block {}: {} leaves", h1, deletes.len());
+
+    // (6) Compute adds (new UTXO leaves) from block H+1
+    let height_code = rpc.get_block_height(&bh1).context("fetch block height")? << 1;
+    let mut adds = Vec::new();
+    for tx in &block1.txdata {
+        for (vout, out) in tx.output.iter().enumerate() {
+            let leaf_data = LeafData {
+                block_hash: bh1,
+                prevout: bitcoin::OutPoint { txid: tx.txid(), vout: vout as u32 },
+                header_code: height_code,
+                utxo: out.clone(),
+            };
+            adds.push(PollardAddition { hash: leaf_data.get_leaf_hashes(), remember: false });
+        }
+    }
+    println!("Adds from block {}: {} leaves", h1, adds.len());
+
+    // (7) Load full MemForest to generate an update proof
+    let mut forest_bytes = Vec::new();
+    File::open("mem_forest.bin").context("opening mem_forest.bin")?
+        .read_to_end(&mut forest_bytes)?;
+    let mut fcur = Cursor::new(&forest_bytes);
+    let mut forest: MemForest<BitcoinNodeHash> =
+        MemForest::deserialize(&mut fcur).context("deserialize forest")?;
+    let proof: Proof<BitcoinNodeHash> = forest
+        .prove(&deletes)
+        .map_err(|e| anyhow!("prove failed: {:?}", e))?;
+
+    // (8) Apply add/delete/proof to the pruned Pollard
+    pollard
+        .modify(&adds, &deletes, proof)
+        .map_err(|e| anyhow!("pollard.modify failed: {:?}", e))?;
+    let new_roots = pollard.roots().to_vec();
+    println!("New Utreexo roots: {:?}", new_roots);
+
+    // (9) Output commit values
+    println!("Commit:");
+    println!("- prev_block_hash = {}", bh0);
+    println!("- prev_utreexo_roots = {:?}", prev_roots);
+    println!("- block_hash = {}", bh1);
+    println!("- new_utreexo_roots = {:?}", new_roots);
+    Ok(())
+}
+
+/// A thin RPCAdapter implementing BitcoinRpc for our usage
+struct RpcClient(Client);
+impl BitcoinRpc for RpcClient {
+    fn get_block_hash(&self, height: u64) -> Result<bitcoin::BlockHash> {
+        Ok(self.0.get_block_hash(height)?)
+    }
+    fn get_block(&self, hash: &bitcoin::BlockHash) -> Result<bitcoin::Block> {
+        Ok(self.0.get_block(hash)?)
+    }
+    fn get_txout(&self, prev: &bitcoin::OutPoint) -> Result<(u64, Vec<u8>)> {
+        let info = self.0.get_raw_transaction_info(&prev.txid, None)?;
+        let v = info.vout.into_iter().find(|v| v.n == prev.vout)
+            .ok_or_else(|| anyhow!("vout not found"))?;
+        Ok((v.value.to_sat(), hex::decode(v.script_pub_key.hex)?))
+    }
+    fn get_block_height(&self, hash: &bitcoin::BlockHash) -> Result<u32> {
+        Ok(self.0.get_block_header_info(hash)?.height as u32)
+    }
+}

--- a/accumulator-service/bin/verify_update.rs
+++ b/accumulator-service/bin/verify_update.rs
@@ -1,16 +1,17 @@
 //! Standalone verifier: loads a pruned Pollard, fetches block H and H+1,
 //! and applies UTXO changes to advance the Pollard.
+use accumulator_service::script_utils::btc_rpc::{get_block_leaf_hashes, BitcoinRpc};
 use anyhow::{anyhow, Context, Result};
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 use clap::Parser;
+use log::{info, warn};
+use rustreexo::accumulator::mem_forest::MemForest;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use rustreexo::accumulator::pollard::{Pollard, PollardAddition};
-use rustreexo::accumulator::mem_forest::MemForest;
 use rustreexo::accumulator::proof::Proof;
 use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::PathBuf;
-use accumulator_service::script_utils::btc_rpc::{get_block_leaf_hashes, BitcoinRpc};
 use utreexo::LeafData;
 
 /// CLI arguments
@@ -26,7 +27,9 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    // Parse arguments
+    // Initialize logger (uses RUST_LOG)
+    env_logger::init();
+    // Parse CLI arguments
     let args = Args::parse();
 
     // (1) Load existing pruned Pollard
@@ -38,11 +41,12 @@ fn main() -> Result<()> {
     let mut pollard: Pollard<BitcoinNodeHash> =
         Pollard::deserialize(&mut rdr).context("failed to deserialize pollard")?;
     let prev_roots = pollard.roots().to_vec();
-    println!("Previous Utreexo roots: {:?}", prev_roots);
+    info!("Previous Utreexo roots: {:?}", prev_roots);
 
     // (2) Connect to local Bitcoin Core RPC
     let rpc_url = std::env::var("BITCOIN_CORE_RPC_URL").context("missing BITCOIN_CORE_RPC_URL")?;
-    let cookie = std::env::var("BITCOIN_CORE_COOKIE_FILE").context("missing BITCOIN_CORE_COOKIE_FILE")?;
+    let cookie =
+        std::env::var("BITCOIN_CORE_COOKIE_FILE").context("missing BITCOIN_CORE_COOKIE_FILE")?;
     let rpc_client = Client::new(&rpc_url, Auth::CookieFile(cookie.into()))
         .context("failed to connect to Bitcoin RPC")?;
     let rpc = RpcClient(rpc_client);
@@ -53,18 +57,20 @@ fn main() -> Result<()> {
     let h1 = args.height + 1;
     let bh1 = rpc.get_block_hash(h1)?;
     let block1 = rpc.get_block(&bh1)?;
-    println!("Block {} hash = {}", args.height, bh0);
-    println!("Block {} hash = {}", h1, bh1);
+    info!("Block {} hash = {}", args.height, bh0);
+    info!("Block {} hash = {}", h1, bh1);
 
     // (4) Verify difficulty target matches between blocks
     if block0.header.bits != block1.header.bits {
-        eprintln!("Warning: bits mismatch: {:?} vs {:?}", block0.header.bits, block1.header.bits);
+        warn!(
+            "Bits mismatch: {:?} vs {:?}",
+            block0.header.bits, block1.header.bits
+        );
     }
 
     // (5) Compute deletes (spent UTXO leaves) for block H+1
-    let deletes = get_block_leaf_hashes(&rpc, h1)
-        .context("failed to fetch block leaf hashes")?;
-    println!("Deletes from block {}: {} leaves", h1, deletes.len());
+    let deletes = get_block_leaf_hashes(&rpc, h1).context("failed to fetch block leaf hashes")?;
+    info!("Deletes from block {}: {} leaves", h1, deletes.len());
 
     // (6) Compute adds (new UTXO leaves) from block H+1
     let height_code = rpc.get_block_height(&bh1).context("fetch block height")? << 1;
@@ -73,21 +79,28 @@ fn main() -> Result<()> {
         for (vout, out) in tx.output.iter().enumerate() {
             let leaf_data = LeafData {
                 block_hash: bh1,
-                prevout: bitcoin::OutPoint { txid: tx.txid(), vout: vout as u32 },
+                prevout: bitcoin::OutPoint {
+                    txid: tx.compute_txid(),
+                    vout: vout as u32,
+                },
                 header_code: height_code,
                 utxo: out.clone(),
             };
-            adds.push(PollardAddition { hash: leaf_data.get_leaf_hashes(), remember: false });
+            adds.push(PollardAddition {
+                hash: leaf_data.get_leaf_hashes(),
+                remember: false,
+            });
         }
     }
-    println!("Adds from block {}: {} leaves", h1, adds.len());
+    info!("Adds from block {}: {} leaves", h1, adds.len());
 
     // (7) Load full MemForest to generate an update proof
     let mut forest_bytes = Vec::new();
-    File::open("mem_forest.bin").context("opening mem_forest.bin")?
+    File::open("mem_forest.bin")
+        .context("opening mem_forest.bin")?
         .read_to_end(&mut forest_bytes)?;
     let mut fcur = Cursor::new(&forest_bytes);
-    let mut forest: MemForest<BitcoinNodeHash> =
+    let forest: MemForest<BitcoinNodeHash> =
         MemForest::deserialize(&mut fcur).context("deserialize forest")?;
     let proof: Proof<BitcoinNodeHash> = forest
         .prove(&deletes)
@@ -98,14 +111,14 @@ fn main() -> Result<()> {
         .modify(&adds, &deletes, proof)
         .map_err(|e| anyhow!("pollard.modify failed: {:?}", e))?;
     let new_roots = pollard.roots().to_vec();
-    println!("New Utreexo roots: {:?}", new_roots);
+    info!("New Utreexo roots: {:?}", new_roots);
 
     // (9) Output commit values
-    println!("Commit:");
-    println!("- prev_block_hash = {}", bh0);
-    println!("- prev_utreexo_roots = {:?}", prev_roots);
-    println!("- block_hash = {}", bh1);
-    println!("- new_utreexo_roots = {:?}", new_roots);
+    info!("Commit:");
+    info!("- prev_block_hash = {}", bh0);
+    info!("- prev_utreexo_roots = {:?}", prev_roots);
+    info!("- block_hash = {}", bh1);
+    info!("- new_utreexo_roots = {:?}", new_roots);
     Ok(())
 }
 
@@ -120,7 +133,10 @@ impl BitcoinRpc for RpcClient {
     }
     fn get_txout(&self, prev: &bitcoin::OutPoint) -> Result<(u64, Vec<u8>)> {
         let info = self.0.get_raw_transaction_info(&prev.txid, None)?;
-        let v = info.vout.into_iter().find(|v| v.n == prev.vout)
+        let v = info
+            .vout
+            .into_iter()
+            .find(|v| v.n == prev.vout)
             .ok_or_else(|| anyhow!("vout not found"))?;
         Ok((v.value.to_sat(), hex::decode(v.script_pub_key.hex)?))
     }

--- a/accumulator-service/src/pollard.rs
+++ b/accumulator-service/src/pollard.rs
@@ -24,6 +24,20 @@ pub async fn prune_forest(snapshot_path: &str, _delete_list: &str) -> Result<()>
         .map_err(|e| anyhow!("failed to serialize Pollard: {}", e))?;
     Ok(())
 }
+/// Synchronous version of prune_forest for use in blocking contexts.
+pub fn prune_forest_sync(snapshot_path: &str, _delete_list: &str) -> Result<()> {
+    // Load the full MemForest bytes
+    let data = fs::read(snapshot_path)?;
+    // Convert to Pollard (empty deletions by default)
+    let pollard =
+        forest_to_pollard(&data, &[]).map_err(|e| anyhow!("pollard conversion failed: {}", e))?;
+    // Serialize Pollard to disk
+    let mut out = fs::File::create("pollard.bin")?;
+    pollard
+        .serialize(&mut out)
+        .map_err(|e| anyhow!("failed to serialize Pollard: {}", e))?;
+    Ok(())
+}
 
 // ----------------------------------------------------------------------------
 // Build an in-memory Pollard reflecting a single block's deletes and additions

--- a/accumulator-service/src/pollard.rs
+++ b/accumulator-service/src/pollard.rs
@@ -1,7 +1,12 @@
-//! Pollard logic stub.
+//! Pollard logic stubs and helpers
 use crate::script_utils::pollard_conv::forest_to_pollard;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use rustreexo::accumulator::mem_forest::MemForest;
+use rustreexo::accumulator::node_hash::BitcoinNodeHash;
+use rustreexo::accumulator::pollard::{Pollard, PollardAddition};
+use rustreexo::accumulator::proof::Proof;
 use std::fs;
+use std::io::Cursor;
 
 /// Prune a MemForest snapshot into a Pollard using the provided delete list (ignored for empty deletions).
 /// Reads the serialized MemForest from `snapshot_path`, runs the forest_to_pollard conversion,
@@ -16,6 +21,67 @@ pub async fn prune_forest(snapshot_path: &str, _delete_list: &str) -> Result<()>
     let mut out = fs::File::create("pollard.bin")?;
     pollard
         .serialize(&mut out)
-        .map_err(|e| anyhow::anyhow!("failed to serialize Pollard: {}", e))?;
+        .map_err(|e| anyhow!("failed to serialize Pollard: {}", e))?;
     Ok(())
+}
+
+// ----------------------------------------------------------------------------
+// Build an in-memory Pollard reflecting a single block's deletes and additions
+// ----------------------------------------------------------------------------
+
+/// Apply a block's deletes (TxIns) and new leaves (TxOuts) to a full `MemForest` in memory,
+/// producing a compact `Pollard` that matches the resulting accumulator root.
+///
+/// Steps:
+/// 1) Deserialize `mem_forest_bytes` into a `MemForest`.
+/// 2) Generate a batch proof for `deletes` (spent leaf hashes).
+/// 3) Create a fresh `Pollard` from the forest's roots + leaf count; call `modify` with the proof.
+/// 4) Append every hash in `new_leaves` as `PollardAddition`.
+/// 5) Apply the same `(new_leaves, deletes)` to the full `MemForest` and assert roots match.
+pub fn pollard_after_block(
+    mem_forest_bytes: &[u8],
+    deletes: &[BitcoinNodeHash],
+    new_leaves: &[BitcoinNodeHash],
+) -> Result<Pollard<BitcoinNodeHash>> {
+    // 1) deserialize full forest
+    let mut cursor = Cursor::new(mem_forest_bytes);
+    let mut mem = MemForest::<BitcoinNodeHash>::deserialize(&mut cursor)
+        .context("deserialize MemForest failed")?;
+
+    // 2) build deletion proof
+    let proof: Proof<BitcoinNodeHash> = mem
+        .prove(deletes)
+        .map_err(|e| anyhow!("prove failed: {e:?}"))?;
+
+    // 3) create Pollard from current roots and apply proof + additions
+    let roots = mem
+        .get_roots()
+        .iter()
+        .map(|r| r.get_data())
+        .collect::<Vec<_>>();
+    let adds = new_leaves
+        .iter()
+        .map(|&h| PollardAddition {
+            hash: h,
+            remember: false,
+        })
+        .collect::<Vec<_>>();
+    let mut pollard = Pollard::from_roots(roots, mem.leaves);
+    pollard
+        .modify(&adds, deletes, proof)
+        .map_err(|e| anyhow!("pollard.modify failed: {e}"))?;
+
+    // 4) sanity check: mirror on MemForest and compare roots
+    mem.modify(new_leaves, deletes)
+        .map_err(|e| anyhow!("mem.modify failed: {e:?}"))?;
+    let expected = mem
+        .get_roots()
+        .iter()
+        .map(|r| r.get_data())
+        .collect::<Vec<_>>();
+    if pollard.roots() != expected {
+        return Err(anyhow!("root mismatch: Pollard vs MemForest after block"));
+    }
+
+    Ok(pollard)
 }

--- a/accumulator-service/src/updater.rs
+++ b/accumulator-service/src/updater.rs
@@ -65,12 +65,10 @@ pub async fn update_block(height: u64) -> Result<()> {
         .context("failed to serialize MemForest")?;
     // After updating the forest, generate a fresh pruned Pollard and write pollard.bin
     // offload pruning to blocking thread since Pollard sync conversion is not Send-safe
-    tokio::task::spawn_blocking(|| {
-        crate::pollard::prune_forest_sync("mem_forest.bin", "")
-    })
-    .await
-    .context("prune_forest task join failed")?
-    .context("failed to prune forest to Pollard")?;
+    tokio::task::spawn_blocking(|| crate::pollard::prune_forest_sync("mem_forest.bin", ""))
+        .await
+        .context("prune_forest task join failed")?
+        .context("failed to prune forest to Pollard")?;
     Ok(())
 }
 /// Synchronous helper for `update_block`, suitable for blocking contexts.

--- a/accumulator-service/tests/http_state.rs
+++ b/accumulator-service/tests/http_state.rs
@@ -22,7 +22,7 @@ async fn start_build_then_conflict_on_second_build() {
     // First /build should be 202 Accepted
     let req1 = test::TestRequest::post()
         .uri("/build")
-        .set_json(&json!({ "parquet": "nonexistent.parquet", "resume_from": null }))
+        .set_json(json!({ "parquet": "nonexistent.parquet", "resume_from": null }))
         .to_request();
     let resp1 = test::call_service(&app, req1).await;
     assert_eq!(resp1.status(), 202);
@@ -30,7 +30,7 @@ async fn start_build_then_conflict_on_second_build() {
     // Second /build while first still running should yield 409 Conflict
     let req2 = test::TestRequest::post()
         .uri("/build")
-        .set_json(&json!({ "parquet": "other.parquet", "resume_from": null }))
+        .set_json(json!({ "parquet": "other.parquet", "resume_from": null }))
         .to_request();
     let resp2 = test::call_service(&app, req2).await;
     assert_eq!(resp2.status(), 409);

--- a/accumulator-service/tests/update_pollard.rs
+++ b/accumulator-service/tests/update_pollard.rs
@@ -1,25 +1,12 @@
 //! Integration test: POST /update should rebuild & dump pruned Pollard
-
 use accumulator_service::{api, Context};
 use actix_web::{test, web::Data, App};
-use serde_json::json;
 use rustreexo::accumulator::mem_forest::MemForest;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
+use serde_json::json;
 use std::fs::File;
 use std::path::Path;
 use std::time::Duration;
-
-/// Wait until service state returns Idle
-async fn wait_idle(ctx: &Context) {
-    loop {
-        let status = ctx.status().await;
-        if matches!(status.state, accumulator_service::state_machine::ServiceState::Idle) {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-}
-
 #[actix_rt::test]
 async fn update_generates_pollard_bin() {
     // isolate in temp dir
@@ -46,7 +33,7 @@ async fn update_generates_pollard_bin() {
     // POST /update (height=0), expect 202
     let req = test::TestRequest::post()
         .uri("/update")
-        .set_json(&json!({ "height": 0 }))
+        .set_json(json!({ "height": 0 }))
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 202);

--- a/accumulator-service/tests/update_pollard.rs
+++ b/accumulator-service/tests/update_pollard.rs
@@ -1,0 +1,64 @@
+//! Integration test: POST /update should rebuild & dump pruned Pollard
+
+use accumulator_service::{api, Context};
+use actix_web::{test, web::Data, App};
+use serde_json::json;
+use rustreexo::accumulator::mem_forest::MemForest;
+use rustreexo::accumulator::node_hash::BitcoinNodeHash;
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+/// Wait until service state returns Idle
+async fn wait_idle(ctx: &Context) {
+    loop {
+        let status = ctx.status().await;
+        if matches!(status.state, accumulator_service::state_machine::ServiceState::Idle) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[actix_rt::test]
+async fn update_generates_pollard_bin() {
+    // isolate in temp dir
+    let tmp = tempfile::tempdir().unwrap();
+    std::env::set_current_dir(tmp.path()).unwrap();
+
+    // prepare minimal mem_forest.bin (empty forest)
+    let forest: MemForest<BitcoinNodeHash> = MemForest::new();
+    let mut f = File::create("mem_forest.bin").unwrap();
+    forest.serialize(&mut f).unwrap();
+
+    // ensure no pollard.bin present
+    assert!(!Path::new("pollard.bin").exists());
+
+    // start service
+    let ctx = Context::new();
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(ctx.clone()))
+            .configure(api::configure),
+    )
+    .await;
+
+    // POST /update (height=0), expect 202
+    let req = test::TestRequest::post()
+        .uri("/update")
+        .set_json(&json!({ "height": 0 }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 202);
+
+    // wait for pollard.bin to be written
+    for _ in 0..20 {
+        if Path::new("pollard.bin").exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // pollard.bin should now exist
+    assert!(Path::new("pollard.bin").exists(), "pollard.bin not created");
+}


### PR DESCRIPTION
Wire /update to rebuild pruned Pollard, add integration test, and improve logging

Description:
This PR completes the final piece of the roadmap by ensuring that every POST /update {height}:

* Loads the existing `mem_forest.bin`, applies deletes for the given block, re-serializes the forest
* Prunes the updated forest into a fresh `pollard.bin` on disk, keeping `block_hashes.bin` in sync
* Runs the forest-prune step in a `spawn_blocking` task via a new `update_block_sync` helper (necessary because `MemForest` is not `Send`)
* Wires the state machine’s `Command::Update` path to call `update_block_sync`

Additional changes:

* Added a new integration test `update_generates_pollard_bin.rs` that boots the HTTP server, POSTs `/update`, and asserts `pollard.bin` appears
* Removed the unused `wait_idle` helper from tests
* Updated README to clarify that `/update` now writes `pollard.bin` alongside updating `mem_forest.bin`
* Refactored the standalone `verify_update` binary in `bin/verify_update.rs` to use `log::info!`/`warn!` instead of `println!`, and initialized logging with `env_logger`
* Applied Clippy suggestions in the HTTP tests—dropped unnecessary `&` in `set_json` calls